### PR TITLE
Non-root version for use in secure clusters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN go build -mod=vendor -a -v -tags 'netgo' -ldflags '-w -extldflags -static' -
 
 FROM alpine:latest
 RUN apk add -U --no-cache curl
+RUN adduser -D 1001
+USER 1001
 COPY app/static /static
 COPY --from=app /go/src/app/docker-demo /bin/docker-demo
 COPY app/templates /templates


### PR DESCRIPTION
Update: Changed to a non-root user for running the app in clusters using admission controllers/PSPs that block containers running as root, for example Rancher clusters with CIS profile enabled.

Works in testing. Can be pulled directly by updating image references in Kustomize overlay to `powerninjas/rancher-demo-1001:non-root`.


